### PR TITLE
feat(website): updated apache2 configuration from apache 2.2 to 2.4

### DIFF
--- a/curation/website/apache_conf/apache2.conf
+++ b/curation/website/apache_conf/apache2.conf
@@ -158,8 +158,7 @@ AccessFileName .htaccess
 # viewed by Web clients. 
 #
 <Files ~ "^\.ht">
-    Order allow,deny
-    Deny from all
+    Require all denied
     Satisfy all
 </Files>
 

--- a/curation/website/apache_conf/httpd.conf
+++ b/curation/website/apache_conf/httpd.conf
@@ -23,44 +23,15 @@ Alias /files ${CALTECH_CURATION_FILES_INTERNAL_PATH}/
 <Directory /usr/lib/pub>
    AllowOverride All
    Options All
-   Order deny,allow
-   Allow from All
+   Require all granted
 </Directory>
 
 <Directory /usr/lib/priv>
    AllowOverride All
    Options All
-   Order deny,allow
-#   Allow from All
-   Deny from All
-   Allow from 127.0.0.1
-   Allow from ${IP_INSIDE_DOCKER}
-# #    Allow from 131.215.34
-#    Allow from 131.215.35.25		# tenaya
-#    Allow from 131.215.35.17		# erich's taygeta
-#    Allow from 131.215.12.61		# elbrus
-#    Allow from 131.215.12.160		# erich's vega
-#    Allow from 131.215.12.159		# erich's altair
-#    Allow from 131.215.12.167		# erich's spica
-#    Allow from 131.215.12.161		# main.textpresso
-# #   Allow from 131.215.145.137		# textpresso-dev for james  twenty-fourteen aug first
-# #   Allow from 131.215.145.81		# textpresso-dev also for james twenty-fourteen aug first
-#    Allow from 131.215.148.181		# textpresso-dev also for james twenty-fifteen aug thirteen
-#    Allow from 131.215.35.42		# erich's alcyone
-#    Allow from 131.215.52		# downstairs church
-#    Allow from 131.215.54		# cecilia's mac, carol's laptop
-#    Allow from 131.215.235.6		# arun's textpresso
-# #    Allow from mindspring.com		# cecilia's home
-# #    Allow from hyq31.no-ip.org		# daniel somewhere
-#    Allow from 128.97.55.104		# daniel somewhere else
-#    Allow from 193.62.203.214		# Mary Ann in Sanger
-# #    Allow from pas-mres.charterpipeline.net	# andrei's home
-#    Allow from 192.168.1.68		# ranjana home
-#    Allow from 131.215.248		# vpn for raymond
-#    Allow from 131.215.249		# vpn for raymond
-#    Allow from 131.215.76.27		# staging textpresso
-#    Allow from 34.208.205.164		# michael aws textpresso	tpc.textpresso.com
-   Order deny,allow
+   Require all denied
+   Require ip 127.0.0.1
+   Require ip ${IP_INSIDE_DOCKER}
    AuthType Basic
    AuthName "Restricted Files"
    AuthUserFile /etc/httpd/passwd/passwords
@@ -71,141 +42,17 @@ Alias /files ${CALTECH_CURATION_FILES_INTERNAL_PATH}/
 <Directory ${CALTECH_CURATION_FILES_INTERNAL_PATH}/pub>
    AllowOverride All
    Options All
-   Order allow,deny
-   Allow from All
+   Require all granted
 </Directory>
 
 <Directory ${CALTECH_CURATION_FILES_INTERNAL_PATH}/priv>
    AllowOverride All
    Options All
-   Order allow,deny
-   Deny from All
-   Order deny,allow
+   Require all denied
    AuthType Basic
    AuthName "Restricted Files"
    AuthUserFile /etc/httpd/passwd/passwords
    Require valid-user
    Satisfy Any
 </Directory>
-
-
-# <Directory /home/azurebrd/public_html>
-#    AllowOverride All
-#    Options All
-#    Order allow,deny
-#    Allow from All
-# #   AllowOverride FileInfo AuthConfig Limit
-# #   Options MultiViews Indexes SymLinksIfOwnerMatch IncludesNoExec
-# #   <Limit GET POST OPTIONS>
-# #       Order allow,deny
-# #       Allow from all
-# #   </Limit>
-# #   <LimitExcept GET POST OPTIONS>
-# #       Order deny,allow
-# #       Deny from all
-# #   </LimitExcept>
-# </Directory>
-
-# <Directory /home/azurebrd/public_html/passwd>
-#    AllowOverride All
-#    Options All
-#    Order allow,deny
-#    Allow from All
-#    AuthType Basic
-#    AuthName "Restricted Files"
-#    AuthUserFile /etc/httpd/passwd/azurebrd_html_passwd
-#    Require valid-user
-# </Directory>
-#
-# <Directory /home/azurebrd/public_html/cgi-bin>
-#    AllowOverride All
-#    Options All
-#    Order allow,deny
-#    Allow from All
-# </Directory>
-#
-# <Directory /home/azurebrd/public_html/cgi-bin/secret>
-#    AllowOverride All
-#    Options All
-# #    Allow from All
-#    Order deny,allow
-#    AuthType Basic
-#    AuthName "Restricted Files"
-#    AuthUserFile /etc/httpd/passwd/passwords
-#    Require valid-user
-# #   Satisfy Any
-# </Directory>
-#
-# <Directory /home/acedb/public_html>
-#    AllowOverride All
-#    Options All
-#    Order allow,deny
-#    Allow from All
-# </Directory>
-#
-# <Directory /home/acedb/public_html/daniel>
-#    AllowOverride All
-#    Options All
-#    Order deny,allow
-# #   Allow from All
-#    Deny from All
-# #    Allow from 127.0.0.1
-# #    Allow from 131.215.34
-#    Allow from 131.215.35.25		# tenaya
-#    Allow from 131.215.35.17		# erich's taygeta
-#    Allow from 131.215.12.160		# erich's vega
-#    Allow from 131.215.12.159		# erich's altair
-#    Allow from 131.215.35.42             # erich's alycone
-#    Allow from 131.215.52		# raymond
-#    Allow from 131.215.54		# cecilia's mac, carol's laptop
-# #    Allow from mindspring.com		# cecilia's home
-# #    Allow from 134.84.59.183		# Theresa at CGC
-# #    Allow from hyq31.no-ip.org		# daniel somewhere
-#    Allow from 128.97.55.104		# daniel somewhere else
-# #    Allow from pas-mres.charterpipeline.net	# andrei's home
-#    Allow from 192.168.1.68		# ranjana home
-# #    Allow from 131.215.235.6		# textpresso-dev	# old, removed 2014 04 06
-# #    Allow from 131.215.145.81		# textpresso-dev
-#    Allow from 131.215.148.181		# textpresso-dev also for james twenty-fifteen aug thirteen
-#    Allow from 131.215.216		# vpn for raymond
-#    Allow from 131.215.217		# vpn for raymond
-#    Allow from 131.215.246		# vpn for raymond
-#    Allow from 131.215.248		# vpn for raymond
-#    Allow from 131.215.249		# vpn for raymond
-#    Allow from 131.215.250		# vpn for raymond
-#    Allow from 131.215.251		# vpn for raymond
-#    Allow from 131.215.252		# vpn for raymond
-#    Allow from 131.215.76.27		# staging textpresso
-#    Allow from 131.215.76.26		# textmining textpresso
-#    Allow from 34.208.205.164		# michael aws textpresso	tpc.textpresso.com
-#    Order deny,allow
-#    AuthType Basic
-#    AuthName "Restricted Files"
-#    AuthUserFile /etc/httpd/passwd/passwords
-#    Require valid-user
-#    Satisfy Any
-# </Directory>
-#
-# <Directory /home/postgres/public_html/michael>
-#    AllowOverride All
-#    Options All
-#    Order deny,allow
-# #   Deny from All
-# #   Allow from 131.215
-#    Allow from All
-# </Directory>
-
-# <Directory /home/rebeccaj/public_html>
-#    AllowOverride All
-#    Options All
-#    Order allow,deny
-#    Allow from All
-# </Directory>
-#
-# <Directory /home/cecilia/public_html>
-#    AllowOverride All
-#    Options All
-#    Order allow,deny
-#    Allow from All
-# </Directory>
 


### PR DESCRIPTION
- Apache was returning a lot of AH01797: client denied by server configuration errors
- Tazendra was using apache 2.2 whereas the new system uses 2.4
- Apache 2.4 uses the new directive 'Require', as described here: https://stackoverflow.com/questions/18392741/apache2-ah01630-client-denied-by-server-configuration
- All apache config files were updated to use Require
- Removed extra comments in config files