### PR TITLE
feat(email): migrate all outgoing mail from gmail to AWS SES

### DIFF
--- a/.env
+++ b/.env
@@ -59,3 +59,21 @@ SRC_DIR_PATH=
 
 ENV_STATE=dev
 VOLUMES_DIR=
+
+# email - aws ses.  Only these two have to be set, they are the SES smtp
+# credentials from the textpresso aws account, and they are the same two
+# variables the ACKnowledge and barista backends use.  EMAIL_SMTP_USER is an
+# opaque credential and not an address, which is why the visible sender is
+# EMAIL_FROM.
+EMAIL_SMTP_USER=
+EMAIL_PASSWD=
+
+# optional overrides, Jex.pm uses its own defaults when these are empty :
+#   EMAIL_HOST      email-smtp.us-east-1.amazonaws.com
+#   EMAIL_PORT      465
+#   EMAIL_FROM      WormBase Curation <no-reply@caltech-curation.textpressolab.com>
+#   EMAIL_REPLY_TO  outreach@wormbase.org
+EMAIL_HOST=
+EMAIL_PORT=
+EMAIL_FROM=
+EMAIL_REPLY_TO=

--- a/.env
+++ b/.env
@@ -72,7 +72,10 @@ EMAIL_PASSWD=
 #   EMAIL_HOST      email-smtp.us-east-1.amazonaws.com
 #   EMAIL_PORT      465
 #   EMAIL_FROM      WormBase Curation <no-reply@caltech-curation.textpressolab.com>
-#   EMAIL_REPLY_TO  outreach@wormbase.org
+#   EMAIL_REPLY_TO  empty, which means the Reply-To is every address the message
+#                   went to, so a reply from a form submitter reaches all the
+#                   curators on the thread.  Set it only to pin every reply to
+#                   one fixed mailbox instead.
 EMAIL_HOST=
 EMAIL_PORT=
 EMAIL_FROM=

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,18 @@
 start-acedb:
 	xhost +local:root
 	docker-compose up -d --build acedb
+
+# COMPOSE is overridable because the prod host has the compose v2 plugin
+# ('docker compose') and older machines have the v1 script ('docker-compose').
+# COMPOSE_ARGS is where '--env-file .env.local' goes when running on a laptop,
+# whose .env leaves SRC_DIR_PATH and ENV_FILE_PATH empty.
+COMPOSE ?= docker compose
+COMPOSE_ARGS ?=
+
+# 'run --rm --no-deps' rather than 'exec', so this works whether or not the
+# curation service is up, and without starting the db.  The two -e flags pass
+# the credentials through from your shell when they are exported, and are inert
+# when they are not, in which case the ones in the env file are used.
+test-mailer:
+	$(COMPOSE) $(COMPOSE_ARGS) run --rm --no-deps -e EMAIL_SMTP_USER -e EMAIL_PASSWD \
+	  curation /usr/lib/scripts/test_mailer.pl -e $(TO)

--- a/README.md
+++ b/README.md
@@ -39,13 +39,23 @@ EMAIL_PASSWD=<SES smtp password>
 ```
 
 `EMAIL_SMTP_USER` is an opaque SES credential, not an address, so the visible
-sender comes from `EMAIL_FROM` instead. `EMAIL_HOST`, `EMAIL_PORT`,
-`EMAIL_FROM` and `EMAIL_REPLY_TO` are optional; when empty, `Jex.pm` uses
-`email-smtp.us-east-1.amazonaws.com`, port 465,
-`WormBase Curation <no-reply@caltech-curation.textpressolab.com>` and
-`outreach@wormbase.org`. `EMAIL_FROM` has to be an SES-verified identity -
-`textpressolab.com` is verified as a parent domain, so any subdomain of it
-works without further DNS setup.
+sender comes from `EMAIL_FROM` instead. `EMAIL_HOST`, `EMAIL_PORT` and
+`EMAIL_FROM` are optional; when empty, `Jex.pm` uses
+`email-smtp.us-east-1.amazonaws.com`, port 465 and
+`WormBase Curation <no-reply@caltech-curation.textpressolab.com>`. `EMAIL_FROM`
+has to be an SES-verified identity - `textpressolab.com` is verified as a parent
+domain, so any subdomain of it works without further DNS setup.
+
+Because that From is a `no-reply@` address, `mailer` always sets a `Reply-To`,
+and by default it is **every address the message went to** - the form submitter
+plus the curators in To and Cc - so a submitter hitting reply reaches all the
+curators on the thread, which is how these forms have always been read. Leaving
+the Reply-To off is not an option: the old From was `outreach@wormbase.org`, a
+mailbox somebody watches, so a plain reply used to arrive somewhere. With a
+no-reply From and no Reply-To it would go nowhere. Set `EMAIL_REPLY_TO` only to
+pin every reply to one fixed mailbox instead; an individual call can also pass
+its own, as the community curation tracker and mass mailer do with
+`curation@wormbase.org`.
 
 `Jex.pm` is copied into the image by `curation/Dockerfile`, it is not bind
 mounted, so a change to the mailer needs a rebuild rather than a restart:

--- a/README.md
+++ b/README.md
@@ -73,12 +73,20 @@ make test-mailer TO=you@example.org COMPOSE_ARGS='--env-file .env.local'   # on 
 ```
 
 `make test-mailer` uses `run --rm --no-deps`, so it works whether or not the
-curation service is up. The equivalent by hand:
+curation service is up. The equivalent by hand, and the way to reproduce the
+shape a form actually sends - submitter in To, curators in Cc, reply reaching
+all of them. `-e`, `-c` and `-r` each take a list: repeat the flag, pass one
+comma separated value, or mix the two.
 
 ```bash
 docker compose run --rm --no-deps \
-  curation /usr/lib/scripts/test_mailer.pl -e you@example.org
+  curation /usr/lib/scripts/test_mailer.pl \
+    -e submitter@example.org \
+    -c cgrove@caltech.edu -c garys@caltech.edu -H
 ```
+
+`test_mailer.pl -h` lists the rest. `TO=` on the make target also accepts a
+comma separated list.
 
 To try credentials without editing the env file first, pass them straight in.
 `Dotenv` does not overwrite variables that are already in the environment, so

--- a/README.md
+++ b/README.md
@@ -22,3 +22,66 @@ $ make start-acedb
 Create grafana/grafana.ini file and modify it with custom config. For example, modify the smtp section to be able to send out email alert notifications. 
 
 grafana/grafana_original.ini contains the original default settings.
+
+### Email (AWS SES)
+
+All outgoing mail - form confirmations, curator notifications, cron job error
+reports, the webinar and community curation mailings - goes through
+`Jex::mailer` in `curation/scripts/perl_modules/Jex.pm`, which talks to AWS SES
+over SMTP.
+
+Set these two in the `.env` file that `ENV_FILE_PATH` points at, using the SES
+SMTP credentials from the textpresso AWS account:
+
+```
+EMAIL_SMTP_USER=<SES smtp username>
+EMAIL_PASSWD=<SES smtp password>
+```
+
+`EMAIL_SMTP_USER` is an opaque SES credential, not an address, so the visible
+sender comes from `EMAIL_FROM` instead. `EMAIL_HOST`, `EMAIL_PORT`,
+`EMAIL_FROM` and `EMAIL_REPLY_TO` are optional; when empty, `Jex.pm` uses
+`email-smtp.us-east-1.amazonaws.com`, port 465,
+`WormBase Curation <no-reply@caltech-curation.textpressolab.com>` and
+`outreach@wormbase.org`. `EMAIL_FROM` has to be an SES-verified identity -
+`textpressolab.com` is verified as a parent domain, so any subdomain of it
+works without further DNS setup.
+
+`Jex.pm` is copied into the image by `curation/Dockerfile`, it is not bind
+mounted, so a change to the mailer needs a rebuild rather than a restart:
+
+```bash
+docker compose up -d --build curation
+```
+
+To check the credentials, send a test message through the same code path the
+forms use:
+
+```bash
+make test-mailer TO=you@example.org                        # on the server
+make test-mailer TO=you@example.org COMPOSE_ARGS='--env-file .env.local'   # on a laptop
+```
+
+`make test-mailer` uses `run --rm --no-deps`, so it works whether or not the
+curation service is up. The equivalent by hand:
+
+```bash
+docker compose run --rm --no-deps \
+  curation /usr/lib/scripts/test_mailer.pl -e you@example.org
+```
+
+To try credentials without editing the env file first, pass them straight in.
+`Dotenv` does not overwrite variables that are already in the environment, so
+these win over the file:
+
+```bash
+docker compose exec -e EMAIL_SMTP_USER -e EMAIL_PASSWD \
+  curation /usr/lib/scripts/test_mailer.pl -e you@example.org
+```
+
+Do not add the `EMAIL_*` variables to the `curation` service's `environment:`
+block in `docker-compose.yml`. Because `Dotenv` yields to whatever is already
+set, an empty value there would shadow the real one in the env file.
+
+Every send is logged to the apache or cron log with a `mailer:` prefix, whether
+it succeeded or failed, so an outage is visible instead of silent.

--- a/curation/scripts/agr_upload/pap_papers/20240321_topic_entity_species/one_time_populate_negative_species_topic_entity.pl
+++ b/curation/scripts/agr_upload/pap_papers/20240321_topic_entity_species/one_time_populate_negative_species_topic_entity.pl
@@ -751,28 +751,5 @@ sub sendErrorEmails {
 sub mailSendmail {
   my ($user, $email, $subject, $body, $cc) = @_;
   if ($ENV{DEVELOPMENT} eq 'true') { $subject = '[dev] ' . $subject; }
-  $email =~ s/\s+//g;
-  my @recipients = split/,/, $email;
-  $cc =~ s/\s+//g;
-  my @cc_recipients = split/,/, $cc;
-  my $smtp = Net::SMTP::SSL->new(
-    'smtp.gmail.com',                       # Gmail SMTP server address
-    Port => 465,                            # Gmail SMTP SSL port
-#     Debug => 1,                             # Enable debugging if needed
-  ) or die "Could not connect to Gmail SMTP server";
-
-  $smtp->auth($ENV{MAILER_USERNAME}, $ENV{MAILER_PASSWORD});
-  $smtp->mail($ENV{MAILER_USERNAME});
-  # $smtp->to(@recipients);                     # might be an alternate way to send
-  $smtp->recipient(@recipients);
-  $smtp->cc(@cc_recipients);                    # don't send cc
-  $smtp->data();
-  $smtp->datasend("From: <$ENV{MAILER_USERNAME}> \n");
-  $smtp->datasend("To: <$email> \n");
-  if ($cc) { $smtp->datasend("cc: <$cc> \n"); }
-  $smtp->datasend("Subject: $subject\n");
-  $smtp->datasend("Content-Type: text/html; charset=iso-8859-1 \n\n");
-  $smtp->datasend($body);
-  $smtp->dataend();
-  $smtp->quit;
+  return &mailer($user, $email, $subject, $body, $cc, 'text/html');	# Jex::mailer, sends through AWS SES
 } # sub mailSendmail

--- a/curation/scripts/agr_upload/pap_papers/20240321_topic_entity_species/one_time_populate_species_topic_entity.pl
+++ b/curation/scripts/agr_upload/pap_papers/20240321_topic_entity_species/one_time_populate_species_topic_entity.pl
@@ -516,28 +516,5 @@ sub sendErrorEmails {
 sub mailSendmail {
   my ($user, $email, $subject, $body, $cc) = @_;
   if ($ENV{DEVELOPMENT} eq 'true') { $subject = '[dev] ' . $subject; }
-  $email =~ s/\s+//g;
-  my @recipients = split/,/, $email;
-  $cc =~ s/\s+//g;
-  my @cc_recipients = split/,/, $cc;
-  my $smtp = Net::SMTP::SSL->new(
-    'smtp.gmail.com',                       # Gmail SMTP server address
-    Port => 465,                            # Gmail SMTP SSL port
-#     Debug => 1,                             # Enable debugging if needed
-  ) or die "Could not connect to Gmail SMTP server";
-
-  $smtp->auth($ENV{MAILER_USERNAME}, $ENV{MAILER_PASSWORD});
-  $smtp->mail($ENV{MAILER_USERNAME});
-  # $smtp->to(@recipients);                     # might be an alternate way to send
-  $smtp->recipient(@recipients);
-  $smtp->cc(@cc_recipients);                    # don't send cc
-  $smtp->data();
-  $smtp->datasend("From: <$ENV{MAILER_USERNAME}> \n");
-  $smtp->datasend("To: <$email> \n");
-  if ($cc) { $smtp->datasend("cc: <$cc> \n"); }
-  $smtp->datasend("Subject: $subject\n");
-  $smtp->datasend("Content-Type: text/html; charset=iso-8859-1 \n\n");
-  $smtp->datasend($body);
-  $smtp->dataend();
-  $smtp->quit;
+  return &mailer($user, $email, $subject, $body, $cc, 'text/html');	# Jex::mailer, sends through AWS SES
 } # sub mailSendmail

--- a/curation/scripts/agr_upload/pap_papers/20240321_topic_entity_species/populate_species_topic_entity.pl
+++ b/curation/scripts/agr_upload/pap_papers/20240321_topic_entity_species/populate_species_topic_entity.pl
@@ -68,6 +68,11 @@
 # DELETE FROM topic_entity_tag WHERE topic_entity_tag_id > 516
 
 
+# Email now goes out through AWS SES with Jex::mailer, which reads
+# EMAIL_SMTP_USER and EMAIL_PASSWD from .env.  Google stopped accepting the
+# gmail app password some time between 2026 05 02 and 2026 05 12, and
+# regenerating it did not help.  2026 08 21
+
 use strict;
 use diagnostics;
 use DBI;
@@ -954,28 +959,5 @@ sub sendErrorEmails {
 sub mailSendmail {
   my ($user, $email, $subject, $body, $cc) = @_;
   if ($ENV{DEVELOPMENT} eq 'true') { $subject = '[dev] ' . $subject; }
-  $email =~ s/\s+//g;
-  my @recipients = split/,/, $email;
-  $cc =~ s/\s+//g;
-  my @cc_recipients = split/,/, $cc;
-  my $smtp = Net::SMTP::SSL->new(
-    'smtp.gmail.com',                       # Gmail SMTP server address
-    Port => 465,                            # Gmail SMTP SSL port
-#     Debug => 1,                             # Enable debugging if needed
-  ) or die "Could not connect to Gmail SMTP server";
-
-  $smtp->auth($ENV{MAILER_USERNAME}, $ENV{MAILER_PASSWORD});
-  $smtp->mail($ENV{MAILER_USERNAME});
-  # $smtp->to(@recipients);                     # might be an alternate way to send
-  $smtp->recipient(@recipients);
-  $smtp->cc(@cc_recipients);                    # don't send cc
-  $smtp->data();
-  $smtp->datasend("From: <$ENV{MAILER_USERNAME}> \n");
-  $smtp->datasend("To: <$email> \n");
-  if ($cc) { $smtp->datasend("cc: <$cc> \n"); }
-  $smtp->datasend("Subject: $subject\n");
-  $smtp->datasend("Content-Type: text/html; charset=iso-8859-1 \n\n");
-  $smtp->datasend($body);
-  $smtp->dataend();
-  $smtp->quit;
+  return &mailer($user, $email, $subject, $body, $cc, 'text/html');	# Jex::mailer, sends through AWS SES
 } # sub mailSendmail

--- a/curation/scripts/community_curation/generate_community_curation_emails.pl
+++ b/curation/scripts/community_curation/generate_community_curation_emails.pl
@@ -20,12 +20,16 @@
 # 2023 03 19
 
 
+# Email now goes out through AWS SES with Jex::mailer, which reads
+# EMAIL_SMTP_USER and EMAIL_PASSWD from .env.  The outreach@wormbase.org
+# password file is no longer read: SES cannot sign for wormbase.org, so the
+# visible sender is EMAIL_FROM and the outreach account stays as the Reply-To.
+# Google stopped accepting the gmail app password some time between 2026 05 02
+# and 2026 05 12, and regenerating it did not help.  2026 08 21
+
 use strict;
 use Jex;		
 use DBI;
-use Email::Send;
-use Email::Send::Gmail;
-use Email::Simple::Creator;
 
 use Dotenv -load => '/usr/lib/.env';
 
@@ -153,8 +157,6 @@ sub sendIndividualMassEmail {
   my $wbperson = $two; $wbperson =~ s/two/WBPerson/;
   my $pgcommand = qq(INSERT INTO com_massemail VALUES ('$paper', '$two', '$email'););
   $toprint .= qq($pgcommand\n);
-# UNCOMMENT TO UPDATE postgres
-  $dbh->do( $pgcommand );
 
 #   my $emailaddress = 'closertothewake@gmail.com';
 #   my $emailaddress = 'cgrove@caltech.edu';
@@ -175,36 +177,19 @@ sub sendIndividualMassEmail {
   $body =~ s/\n/<br\/>\n/g;
 
 
-  my $sender = 'outreach@wormbase.org';
   my $replyto = 'curation@wormbase.org';
-  my $email = Email::Simple->create(
-    header => [
-        From       => 'outreach@wormbase.org',
-        'Reply-to' => 'curation@wormbase.org',
-        To         => "$emailaddress",
-        Subject    => "$subject",
-        'Content-Type' => 'text/html', 
-    ],
-    body => "$body",
-  );
+  # com_massemail is what marks an author as already contacted, so it is only
+  # written after the send succeeded.  Recording it first would burn the author
+  # on a failed send and they would never be asked again.  Jex::mailer sends
+  # through AWS SES and returns false when the message did not go out.
+  unless (&mailer('', $emailaddress, $subject, $body, '', 'text/html', $replyto)) {
+    $toprint .= qq(ERROR : email to $emailaddress was not sent, see the mailer: line in the log.  Not recorded in com_massemail.\n);
+    return $toprint;
+  }
+# UNCOMMENT TO UPDATE postgres
+  $dbh->do( $pgcommand );
   $body =~ s/\n/ /g;
-  $toprint .= qq(send email to $emailaddress\nfrom $sender\nreplyto $replyto\nsubject $subject\nbody $body\n);
-
-  my $passfile = $ENV{CALTECH_CURATION_FILES_INTERNAL_PATH} . '/insecure/outreachwormbase';
-  # my $passfile = '/home/postgres/insecure/outreachwormbase';
-  open (IN, "<$passfile") or die "Cannot open $passfile : $!";
-  my $password = <IN>; chomp $password;
-  close (IN) or die "Cannot close $passfile : $!";
-  my $sender = Email::Send->new(
-    {   mailer      => 'Gmail',
-        mailer_args => [
-           username => 'outreach@wormbase.org',
-           password => "$password",
-        ]
-    }
-  );
-  eval { $sender->send($email) };
-  die "Error sending email: $@" if $@;
+  $toprint .= qq(send email to $emailaddress\nreplyto $replyto\nsubject $subject\nbody $body\n);
 
   return $toprint;
 } # sub sendIndividualMassEmail

--- a/curation/scripts/perl_modules/Jex.pm
+++ b/curation/scripts/perl_modules/Jex.pm
@@ -342,6 +342,14 @@ sub mailer {                    # send non-attachment mail through AWS SES
   # with no Reply-To a plain reply would go nowhere.  An explicit argument wins,
   # then EMAIL_REPLY_TO from .env when it is set to a fixed address on purpose.
   unless ($reply_to) { $reply_to = $ENV{EMAIL_REPLY_TO}; }
+  if ($reply_to) {			# tidy a list that came in with stray spaces or a trailing comma
+    my @replyToAddresses;
+    foreach my $address (split/,/, $reply_to) {
+      $address =~ s/^\s+//; $address =~ s/\s+$//;	# trim around only, a display name may contain spaces
+      if ($address =~ m/\S/) { push @replyToAddresses, $address; }
+    }
+    $reply_to = join(', ', @replyToAddresses);
+  }
   unless ($reply_to) { $reply_to = join(', ', @recipients, @cc_recipients); }
   if (utf8::is_utf8($body))    { $body    = encode('UTF-8', $body); }		# else Email::Simple warns 'Body with wide characters' and sends mangled bytes
   if (utf8::is_utf8($subject)) { $subject = encode('MIME-Header', $subject); }	# rfc 2047 for a non-ascii subject

--- a/curation/scripts/perl_modules/Jex.pm
+++ b/curation/scripts/perl_modules/Jex.pm
@@ -295,43 +295,113 @@ sub getHtmlVarFree {            # get variables from html form and do not untain
   } # else # if ($query->param("$var"))
 } # sub getHtmlVarFree
 
-sub mailer {                    # send non-attachment mail
-  my ($user, $email, $subject, $body) = @_;
+# AWS SES SMTP settings.  Only EMAIL_SMTP_USER and EMAIL_PASSWD have to be set
+# in /usr/lib/.env - the same two variables the ACKnowledge and barista backends
+# read.  The other four are optional overrides.
+# Gmail used to double as the sender address, but the SES SMTP username is an
+# opaque credential rather than an address, so the visible sender now comes from
+# EMAIL_FROM.  EMAIL_FROM has to be an SES-verified identity; textpressolab.com
+# is verified as a parent domain, so any subdomain of it sends without further
+# DNS setup.  no-reply@ is unattended, which is why a Reply-To is always set.
+my $DEFAULT_EMAIL_HOST     = 'email-smtp.us-east-1.amazonaws.com';
+my $DEFAULT_EMAIL_PORT     = 465;
+my $DEFAULT_EMAIL_FROM     = 'WormBase Curation <no-reply@caltech-curation.textpressolab.com>';
+my $DEFAULT_EMAIL_REPLY_TO = 'outreach@wormbase.org';
+
+sub bareEmailAddress {		# 'Some Name <a@b.org>' becomes 'a@b.org' for the smtp envelope
+  my $address = shift;
+  if ($address =~ m/<([^>]+)>/) { $address = $1; }
+  $address =~ s/^\s+//; $address =~ s/\s+$//;
+  return $address;
+} # sub bareEmailAddress
+
+sub mailer {                    # send non-attachment mail through AWS SES
+  # $user is accepted but unused, so that the existing call sites keep working.
+  # The visible sender must be an SES-verified identity now, it can no longer be
+  # whatever address the caller happened to pass in.
+  my ($user, $email, $subject, $body, $cc, $content_type, $reply_to) = @_;
+  my $host = $ENV{EMAIL_HOST} || $DEFAULT_EMAIL_HOST;
+  my $port = $ENV{EMAIL_PORT} || $DEFAULT_EMAIL_PORT;
+  my $from = $ENV{EMAIL_FROM} || $DEFAULT_EMAIL_FROM;
+  unless ($reply_to) { $reply_to = $ENV{EMAIL_REPLY_TO} || $DEFAULT_EMAIL_REPLY_TO; }
+  unless (defined $email)   { $email   = ''; }
+  unless (defined $cc)      { $cc      = ''; }
+  unless (defined $body)    { $body    = ''; }
+  unless (defined $subject) { $subject = ''; }
+  unless ($content_type)    { $content_type = 'text/plain'; }
+  unless ($content_type =~ m/charset/i) { $content_type .= '; charset=UTF-8'; }
   $email =~ s/\s+//g;
-  my @recipients = split/,/, $email;
+  $cc    =~ s/\s+//g;
+  my @recipients    = grep { m/\S/ } split/,/, $email;
+  my @cc_recipients = grep { m/\S/ } split/,/, $cc;
+  unless (@recipients || @cc_recipients) {
+    warn qq(mailer: no recipients for "$subject", nothing sent\n); return 0; }
   if (utf8::is_utf8($body))    { $body    = encode('UTF-8', $body); }		# else Email::Simple warns 'Body with wide characters' and sends mangled bytes
   if (utf8::is_utf8($subject)) { $subject = encode('MIME-Header', $subject); }	# rfc 2047 for a non-ascii subject
+  my @header = ( From => $from, To => join(', ', @recipients) );
+  if (@cc_recipients) { push @header, ( Cc => join(', ', @cc_recipients) ); }
+  if ($reply_to)      { push @header, ( 'Reply-To' => $reply_to ); }
+  push @header, ( Subject        => $subject,
+                  'MIME-Version' => '1.0',
+                  'Content-Type' => $content_type );
   my $email_object = Email::Simple->create(
-      header => [
-          From           => $ENV{MAILER_USERNAME},
-          To             => join(', ', @recipients),
-#           To      => $email,				# if one email
-#           Cc      => join(', ', @cc_recipients),	# if cc values
-          Subject        => $subject,
-          'MIME-Version' => '1.0',
-          'Content-Type' => 'text/plain; charset=UTF-8',
-      ],
-      body => $body,
+      header => \@header,
+      body   => $body,
   );
-  my $smtp = Net::SMTP::SSL->new(
-    'smtp.gmail.com',                       # Gmail SMTP server address
-    Port => 465,                            # Gmail SMTP SSL port
-#     Debug => 1,                             # Enable debugging if needed
-  ) or die "Could not connect to Gmail SMTP server";
 
-  $smtp->auth($ENV{MAILER_USERNAME}, $ENV{MAILER_PASSWORD});
-  $smtp->mail($ENV{MAILER_USERNAME});
-  # $smtp->to(@recipients);                     # might be an alternate way to send
-  $smtp->recipient(@recipients);
-  # $smtp->cc(@cc_recipients);                  # don't send cc here
-  $smtp->data();
+  unless ($ENV{EMAIL_SMTP_USER} && $ENV{EMAIL_PASSWD}) {
+    warn qq(mailer: EMAIL_SMTP_USER / EMAIL_PASSWD not set in .env, "$subject" not sent\n); return 0; }
+
+  # Send failures are logged and returned, not fatal.  Form submissions are
+  # already written to postgres by the time the confirmation mail goes out, so
+  # dying here would show the submitter an error page for data that did save.
+  # Callers that care can check the return value; every outcome lands in the
+  # apache or cron log with a 'mailer:' prefix so an outage is visible.
+  my $smtp = Net::SMTP::SSL->new( $host, Port => $port );
+  unless ($smtp) {
+    warn qq(mailer: cannot connect to $host:$port, "$subject" not sent\n); return 0; }
+  unless ($smtp->auth($ENV{EMAIL_SMTP_USER}, $ENV{EMAIL_PASSWD})) {
+    warn qq(mailer: smtp auth failed at $host, "$subject" not sent : ) . &smtpError($smtp);
+    $smtp->quit; return 0; }
+  unless ($smtp->mail(&bareEmailAddress($from))) {
+    warn qq(mailer: sender $from rejected by $host, "$subject" not sent : ) . &smtpError($smtp);
+    $smtp->quit; return 0; }
+  # SkipBad, because Net::SMTP::recipient otherwise fails the whole call on the
+  # first rejected address.  Forms put a submitter-typed address in To and the
+  # curators in Cc, so one typo would drop the curators' copy too, which the
+  # gmail code did deliver.  Only give up when nothing at all was accepted.
+  my @allRecipients = (@recipients, @cc_recipients);
+  my @accepted = $smtp->recipient(@allRecipients, { SkipBad => 1 });
+  unless (@accepted) {
+    warn qq(mailer: every recipient rejected by $host, "$subject" not sent : ) . &smtpError($smtp);
+    $smtp->quit; return 0; }
+  if (scalar(@accepted) < scalar(@allRecipients)) {
+    my %isAccepted; foreach my $address (@accepted) { $isAccepted{$address}++; }
+    my @rejected = grep { ! $isAccepted{$_} } @allRecipients;
+    warn qq(mailer: $host rejected ) . join(', ', @rejected) . qq( for "$subject", sending to the others\n); }
+  unless ($smtp->data()) {
+    warn qq(mailer: $host refused DATA, "$subject" not sent : ) . &smtpError($smtp);
+    $smtp->quit; return 0; }			# else datasend writes the body where the server expects commands
   $smtp->datasend($email_object->as_string);
-  $smtp->dataend();
+  unless ($smtp->dataend()) {
+    warn qq(mailer: $host refused the message, "$subject" not sent : ) . &smtpError($smtp);
+    $smtp->quit; return 0; }
   $smtp->quit;
+  warn qq(mailer: sent "$subject" to ) . join(', ', @accepted) . qq(\n);
+  return 1;
 
   # sample use
   # if ( $send_email) { &mailer($user, $email, $subject, $body); }
+  # html with a cc and a form specific reply-to :
+  # &mailer($user, $email, $subject, $body, $cc, 'text/html', 'curation@wormbase.org');
 } # sub mailer
+
+sub smtpError {			# last response from the smtp server, for the log line
+  my $smtp = shift;
+  my $message = $smtp->message(); unless (defined $message) { $message = ''; }
+  $message =~ s/\s+/ /g; $message =~ s/\s+$//;
+  return $smtp->code() . qq( $message\n);
+} # sub smtpError
 
 sub old_tazendra_mailer {            	# send non-attachment mail
   my ($user, $email, $subject, $body) = @_;

--- a/curation/scripts/perl_modules/Jex.pm
+++ b/curation/scripts/perl_modules/Jex.pm
@@ -302,11 +302,10 @@ sub getHtmlVarFree {            # get variables from html form and do not untain
 # opaque credential rather than an address, so the visible sender now comes from
 # EMAIL_FROM.  EMAIL_FROM has to be an SES-verified identity; textpressolab.com
 # is verified as a parent domain, so any subdomain of it sends without further
-# DNS setup.  no-reply@ is unattended, which is why a Reply-To is always set.
-my $DEFAULT_EMAIL_HOST     = 'email-smtp.us-east-1.amazonaws.com';
-my $DEFAULT_EMAIL_PORT     = 465;
-my $DEFAULT_EMAIL_FROM     = 'WormBase Curation <no-reply@caltech-curation.textpressolab.com>';
-my $DEFAULT_EMAIL_REPLY_TO = 'outreach@wormbase.org';
+# DNS setup.
+my $DEFAULT_EMAIL_HOST = 'email-smtp.us-east-1.amazonaws.com';
+my $DEFAULT_EMAIL_PORT = 465;
+my $DEFAULT_EMAIL_FROM = 'WormBase Curation <no-reply@caltech-curation.textpressolab.com>';
 
 sub bareEmailAddress {		# 'Some Name <a@b.org>' becomes 'a@b.org' for the smtp envelope
   my $address = shift;
@@ -323,7 +322,6 @@ sub mailer {                    # send non-attachment mail through AWS SES
   my $host = $ENV{EMAIL_HOST} || $DEFAULT_EMAIL_HOST;
   my $port = $ENV{EMAIL_PORT} || $DEFAULT_EMAIL_PORT;
   my $from = $ENV{EMAIL_FROM} || $DEFAULT_EMAIL_FROM;
-  unless ($reply_to) { $reply_to = $ENV{EMAIL_REPLY_TO} || $DEFAULT_EMAIL_REPLY_TO; }
   unless (defined $email)   { $email   = ''; }
   unless (defined $cc)      { $cc      = ''; }
   unless (defined $body)    { $body    = ''; }
@@ -336,6 +334,15 @@ sub mailer {                    # send non-attachment mail through AWS SES
   my @cc_recipients = grep { m/\S/ } split/,/, $cc;
   unless (@recipients || @cc_recipients) {
     warn qq(mailer: no recipients for "$subject", nothing sent\n); return 0; }
+  # Reply-To defaults to everyone the message went to, so that a submitter
+  # hitting reply reaches all the curators on the thread, which is how these
+  # forms have always been read.  It cannot just be left off: the old From was
+  # outreach@wormbase.org, a mailbox somebody watches, but EMAIL_FROM is a
+  # no-reply address because SES will only sign for a domain it has verified, so
+  # with no Reply-To a plain reply would go nowhere.  An explicit argument wins,
+  # then EMAIL_REPLY_TO from .env when it is set to a fixed address on purpose.
+  unless ($reply_to) { $reply_to = $ENV{EMAIL_REPLY_TO}; }
+  unless ($reply_to) { $reply_to = join(', ', @recipients, @cc_recipients); }
   if (utf8::is_utf8($body))    { $body    = encode('UTF-8', $body); }		# else Email::Simple warns 'Body with wide characters' and sends mangled bytes
   if (utf8::is_utf8($subject)) { $subject = encode('MIME-Header', $subject); }	# rfc 2047 for a non-ascii subject
   my @header = ( From => $from, To => join(', ', @recipients) );

--- a/curation/scripts/test_mailer.pl
+++ b/curation/scripts/test_mailer.pl
@@ -24,30 +24,45 @@
 
 use strict;
 use Getopt::Long;
+Getopt::Long::Configure('no_ignore_case');	# else -H for html collides with -h for help
 $| = 1;				# unbuffered, so the mailer: lines on stderr stay in order with this output
 use Jex;			# mailer getSimpleSecDate
 use Dotenv -load => '/usr/lib/.env';
 
-my $recipient    = '';
-my $cc           = '';
+# -e, -c and -r each take a list of addresses.  Repeat the flag, or pass one
+# comma separated value, or mix the two - the forms do the same thing, since
+# Jex::mailer takes comma separated lists.
+my @recipientArgs;
+my @ccArgs;
+my @replyToArgs;
 my $subject      = '';
 my $content_type = 'text/plain';
-my $reply_to     = '';
 my $help         = 0;
 
-GetOptions( 'email|e=s'    => \$recipient,
-            'cc|c=s'       => \$cc,
+GetOptions( 'email|e=s@'   => \@recipientArgs,
+            'cc|c=s@'      => \@ccArgs,
             'subject|s=s'  => \$subject,
             'html|H'       => sub { $content_type = 'text/html'; },
-            'replyto|r=s'  => \$reply_to,
+            'replyto|r=s@' => \@replyToArgs,
             'help|h'       => \$help,
           ) or &usage(1);
 
 if ($help) { &usage(0); }
-unless ($recipient) { print qq(\nERROR : -e <recipient> is required\n); &usage(1); }
+
+my @recipientList = &addressList(@recipientArgs);
+my @ccList        = &addressList(@ccArgs);
+my @replyToList   = &addressList(@replyToArgs);
+unless (@recipientList) { print qq(\nERROR : at least one -e <recipient> is required\n); &usage(1); }
+
+my $recipient = join(', ', @recipientList);
+my $cc        = join(', ', @ccList);
+my $reply_to  = join(', ', @replyToList);
 
 &checkJexIsCurrent();
 &showConfiguration();
+
+my $replyToForBody = $reply_to;
+unless ($replyToForBody) { $replyToForBody = 'every recipient of this message'; }
 
 my $timestamp = &getSimpleSecDate();
 unless ($subject) { $subject = qq(WormBase curation mailer test $timestamp); }
@@ -59,14 +74,16 @@ If you are reading it, Jex::mailer reached AWS SES with the credentials in
 
 sent at       : $timestamp
 content type  : $content_type
-recipients    : $recipient
+to            : $recipient
 cc            : $cc
+reply-to      : $replyToForBody
 );
 if ($content_type eq 'text/html') { $body =~ s/\n/<br\/>\n/g; }
 
-print qq(sending $content_type to $recipient);
-if ($cc) { print qq( , cc $cc); }
-print qq( ...\n\n);
+print qq(sending $content_type to ) . scalar(@recipientList) . qq( recipient(s) : $recipient\n);
+if ($cc)       { print qq(              cc ) . scalar(@ccList) . qq( : $cc\n); }
+if ($reply_to) { print qq(        reply-to ) . scalar(@replyToList) . qq( : $reply_to\n); }
+print qq(\n);
 
 # Same call the forms make.  $user is the first argument and is ignored by
 # mailer, it is only still there so the old call sites did not have to change.
@@ -106,6 +123,7 @@ sub showConfiguration {
   print qq(  EMAIL_SMTP_USER : $user\n);
   print qq(  EMAIL_PASSWD    : $passwd\n);
   if ($reply_to) { print qq(  Reply-To for this message, from -r : $reply_to\n); }
+  else           { print qq(  Reply-To for this message          : the To and Cc addresses below\n); }
   print qq(\n);
 } # sub showConfiguration
 
@@ -126,6 +144,18 @@ sub checkJexIsCurrent {
   print qq(          and then this script again, otherwise you are testing the old mailer.\n);
 } # sub checkJexIsCurrent
 
+sub addressList {		# flatten repeated flags and comma separated values into one list
+  my @values = @_;
+  my @addresses;
+  foreach my $value (@values) {
+    foreach my $address (split /,/, $value) {
+      $address =~ s/^\s+//; $address =~ s/\s+$//;	# trim around, but keep any display name intact
+      if ($address =~ m/\S/) { push @addresses, $address; }
+    }
+  }
+  return @addresses;
+} # sub addressList
+
 sub slurp {
   my $file = shift;
   open (IN, "<$file") or return undef;
@@ -140,18 +170,34 @@ sub usage {
   print qq(
 usage : test_mailer.pl -e <recipient> [options]
 
-  -e, --email <address>     where to send the test message.  Comma separated for
-                            more than one recipient.  Required.
-  -c, --cc <address>        comma separated cc recipients.
+  -e, --email <list>        where to send the test message.  Required.
+  -c, --cc <list>           cc recipients.
+  -r, --replyto <list>      Reply-To for this message.  Without it, Jex::mailer
+                            defaults the Reply-To to every recipient of the
+                            message, which is what the forms rely on so that a
+                            reply reaches all the curators on the thread.
   -s, --subject <text>      subject line.  Defaults to a timestamped one.
   -H, --html                send as text/html instead of text/plain.
-  -r, --replyto <address>   override the Reply-To for this message only.
   -h, --help                this message.
+
+Each <list> is one or more addresses.  Repeat the flag, or pass a comma
+separated value, or mix the two.
 
 examples :
 
   docker compose exec curation /usr/lib/scripts/test_mailer.pl -e you\@example.org
-  docker compose exec curation /usr/lib/scripts/test_mailer.pl -e you\@example.org -H
+
+  # the shape a form sends : submitter in To, curators in Cc, reply reaches all
+  docker compose exec curation /usr/lib/scripts/test_mailer.pl \\
+    -e submitter\@example.org \\
+    -c cgrove\@caltech.edu -c garys\@caltech.edu -H
+
+  # same thing with comma separated lists, and a fixed Reply-To
+  docker compose exec curation /usr/lib/scripts/test_mailer.pl \\
+    -e 'submitter\@example.org, second\@example.org' \\
+    -c 'cgrove\@caltech.edu, garys\@caltech.edu' \\
+    -r 'curation\@wormbase.org, outreach\@wormbase.org'
+
   make test-mailer TO=you\@example.org
 
 );

--- a/curation/scripts/test_mailer.pl
+++ b/curation/scripts/test_mailer.pl
@@ -1,0 +1,159 @@
+#!/usr/bin/env perl
+
+# test_mailer.pl - send one test message through Jex::mailer, the same code path
+# every form and cron job in this repo uses, to check that the AWS SES
+# credentials in .env actually work.
+#
+# Run it inside the curation container, so that it reads the same /usr/lib/.env
+# the forms read :
+#   docker compose exec curation /usr/lib/scripts/test_mailer.pl -e you@example.org
+# or
+#   make test-mailer TO=you@example.org
+#
+# Jex.pm is copied into the image by curation/Dockerfile, it is not bind
+# mounted, so after editing it you have to
+#   docker compose up -d --build curation
+# before this script can see the change.  It compares the copy it loaded against
+# the one in the mounted source tree and complains if they differ, because
+# otherwise a rebuild that did not happen looks exactly like a code change that
+# did not work.
+#
+# Exits 0 when the message was accepted by the smtp server, 1 otherwise.
+#
+# 2026 08 21
+
+use strict;
+use Getopt::Long;
+$| = 1;				# unbuffered, so the mailer: lines on stderr stay in order with this output
+use Jex;			# mailer getSimpleSecDate
+use Dotenv -load => '/usr/lib/.env';
+
+my $recipient    = '';
+my $cc           = '';
+my $subject      = '';
+my $content_type = 'text/plain';
+my $reply_to     = '';
+my $help         = 0;
+
+GetOptions( 'email|e=s'    => \$recipient,
+            'cc|c=s'       => \$cc,
+            'subject|s=s'  => \$subject,
+            'html|H'       => sub { $content_type = 'text/html'; },
+            'replyto|r=s'  => \$reply_to,
+            'help|h'       => \$help,
+          ) or &usage(1);
+
+if ($help) { &usage(0); }
+unless ($recipient) { print qq(\nERROR : -e <recipient> is required\n); &usage(1); }
+
+&checkJexIsCurrent();
+&showConfiguration();
+
+my $timestamp = &getSimpleSecDate();
+unless ($subject) { $subject = qq(WormBase curation mailer test $timestamp); }
+
+my $body = qq(This is a test message from test_mailer.pl.
+
+If you are reading it, Jex::mailer reached AWS SES with the credentials in
+/usr/lib/.env, and the forms and cron jobs that call it can send mail again.
+
+sent at       : $timestamp
+content type  : $content_type
+recipients    : $recipient
+cc            : $cc
+);
+if ($content_type eq 'text/html') { $body =~ s/\n/<br\/>\n/g; }
+
+print qq(sending $content_type to $recipient);
+if ($cc) { print qq( , cc $cc); }
+print qq( ...\n\n);
+
+# Same call the forms make.  $user is the first argument and is ignored by
+# mailer, it is only still there so the old call sites did not have to change.
+my $sent = &mailer('test_mailer.pl', $recipient, $subject, $body, $cc, $content_type, $reply_to);
+
+print qq(\n);
+if ($sent) {
+  print qq(SUCCESS - the smtp server accepted the message.\n);
+  print qq(Check the inbox of $recipient, and the spam folder too : a first message\n);
+  print qq(from a new sending domain often lands there.\n);
+  exit 0;
+} else {
+  print qq(FAILURE - the message was not sent.\n);
+  print qq(The reason is on the 'mailer:' line above, printed to stderr by Jex::mailer.\n);
+  print qq(Common causes :\n);
+  print qq(  - EMAIL_SMTP_USER / EMAIL_PASSWD missing from /usr/lib/.env\n);
+  print qq(  - the SES smtp credentials are for a different aws region than EMAIL_HOST\n);
+  print qq(  - EMAIL_FROM is not a verified SES identity in that aws account\n);
+  print qq(  - the SES account is still in the sandbox, which only allows verified recipients\n);
+  exit 1;
+}
+
+sub showConfiguration {
+  my $host     = $ENV{EMAIL_HOST}     || '(default in Jex.pm)';
+  my $port     = $ENV{EMAIL_PORT}     || '(default in Jex.pm)';
+  my $from     = $ENV{EMAIL_FROM}     || '(default in Jex.pm)';
+  my $replyto  = $ENV{EMAIL_REPLY_TO} || '(default in Jex.pm)';
+  # Never print the credentials themselves, this runs on a shared server and
+  # the output gets pasted into tickets and emails.
+  my $user     = $ENV{EMAIL_SMTP_USER} ? 'set (' . length($ENV{EMAIL_SMTP_USER}) . ' characters)' : 'NOT SET';
+  my $passwd   = $ENV{EMAIL_PASSWD}    ? 'set (' . length($ENV{EMAIL_PASSWD})    . ' characters)' : 'NOT SET';
+  print qq(\nmailer configuration, from /usr/lib/.env\n);
+  print qq(  EMAIL_HOST      : $host\n);
+  print qq(  EMAIL_PORT      : $port\n);
+  print qq(  EMAIL_FROM      : $from\n);
+  print qq(  EMAIL_REPLY_TO  : $replyto\n);
+  print qq(  EMAIL_SMTP_USER : $user\n);
+  print qq(  EMAIL_PASSWD    : $passwd\n);
+  if ($reply_to) { print qq(  Reply-To for this message, from -r : $reply_to\n); }
+  print qq(\n);
+} # sub showConfiguration
+
+sub checkJexIsCurrent {
+  my $loaded = $INC{'Jex.pm'};
+  unless ($loaded) { return; }
+  my $source = '/usr/lib/scripts/perl_modules/Jex.pm';
+  print qq(\nJex.pm loaded from $loaded\n);
+  unless (-e $source)      { return; }
+  if ($loaded eq $source)  { return; }
+  my $loadedText = &slurp($loaded);
+  my $sourceText = &slurp($source);
+  unless (defined $loadedText && defined $sourceText) { return; }
+  if ($loadedText eq $sourceText) { return; }
+  print qq(\nWARNING : the Jex.pm in the image differs from $source\n);
+  print qq(          The image was built from an older Jex.pm.  Run\n);
+  print qq(            docker compose up -d --build curation\n);
+  print qq(          and then this script again, otherwise you are testing the old mailer.\n);
+} # sub checkJexIsCurrent
+
+sub slurp {
+  my $file = shift;
+  open (IN, "<$file") or return undef;
+  local $/;
+  my $text = <IN>;
+  close (IN);
+  return $text;
+} # sub slurp
+
+sub usage {
+  my $exit = shift;
+  print qq(
+usage : test_mailer.pl -e <recipient> [options]
+
+  -e, --email <address>     where to send the test message.  Comma separated for
+                            more than one recipient.  Required.
+  -c, --cc <address>        comma separated cc recipients.
+  -s, --subject <text>      subject line.  Defaults to a timestamped one.
+  -H, --html                send as text/html instead of text/plain.
+  -r, --replyto <address>   override the Reply-To for this message only.
+  -h, --help                this message.
+
+examples :
+
+  docker compose exec curation /usr/lib/scripts/test_mailer.pl -e you\@example.org
+  docker compose exec curation /usr/lib/scripts/test_mailer.pl -e you\@example.org -H
+  make test-mailer TO=you\@example.org
+
+);
+  exit $exit;
+} # sub usage

--- a/curation/scripts/test_mailer.pl
+++ b/curation/scripts/test_mailer.pl
@@ -93,7 +93,7 @@ sub showConfiguration {
   my $host     = $ENV{EMAIL_HOST}     || '(default in Jex.pm)';
   my $port     = $ENV{EMAIL_PORT}     || '(default in Jex.pm)';
   my $from     = $ENV{EMAIL_FROM}     || '(default in Jex.pm)';
-  my $replyto  = $ENV{EMAIL_REPLY_TO} || '(default in Jex.pm)';
+  my $replyto  = $ENV{EMAIL_REPLY_TO} || '(not set, so the reply goes to every recipient of the message)';
   # Never print the credentials themselves, this runs on a shared server and
   # the output gets pasted into tickets and emails.
   my $user     = $ENV{EMAIL_SMTP_USER} ? 'set (' . length($ENV{EMAIL_SMTP_USER}) . ' characters)' : 'NOT SET';

--- a/curation/website/priv/cgi-bin/community_curation_tracker.cgi
+++ b/curation/website/priv/cgi-bin/community_curation_tracker.cgi
@@ -94,15 +94,19 @@
 
 
 
+# Email now goes out through AWS SES with Jex::mailer, which reads
+# EMAIL_SMTP_USER and EMAIL_PASSWD from .env.  The outreach@wormbase.org
+# password file is no longer read: SES cannot sign for wormbase.org, so the
+# visible sender is EMAIL_FROM and the outreach account stays as the Reply-To.
+# Google stopped accepting the gmail app password some time between 2026 05 02
+# and 2026 05 12, and regenerating it did not help.  2026 08 21
+
 use strict;
 use CGI;
 use Jex;		# printHeader printFooter getHtmlVar getDate getSimpleDate mailer
 use LWP::UserAgent;	# getting sanger files for querying
 use LWP::Simple;	# get the PhenOnt.obo from a cgi
 use DBI;
-use Email::Send;
-use Email::Send::Gmail;
-use Email::Simple::Creator;
 use Tie::IxHash;
 use Dotenv -load => '/usr/lib/.env';
 
@@ -852,34 +856,15 @@ sub sendEmail {
   ($var, my $subject)        = &getHtmlVar($query, 'subject');
   ($var, my $body)           = &getHtmlVar($query, 'body');
   ($var, my $datatype)       = &getHtmlVar($query, 'datatype');
-  my $sender = 'outreach@wormbase.org';
   my $replyto = 'curation@wormbase.org';
-  print qq(send email to $emailaddress<br/>from $sender<br/>replyto $replyto<br/>subject $subject<br/>body $body<br/>);
-  my $email = Email::Simple->create(
-    header => [
-        From       => 'outreach@wormbase.org',
-        'Reply-to' => 'curation@wormbase.org',
-        To         => "$emailaddress",
-        Subject    => "$subject",
-    ],
-    body => "$body",
-  );
-
-  my $passfile = $ENV{CALTECH_CURATION_FILES_INTERNAL_PATH} . '/insecure/outreachwormbase';
-  # my $passfile = '/home/postgres/insecure/outreachwormbase';
-  open (IN, "<$passfile") or die "Cannot open $passfile : $!";
-  my $password = <IN>; chomp $password;
-  close (IN) or die "Cannot close $passfile : $!";
-  my $sender = Email::Send->new(
-    {   mailer      => 'Gmail',
-        mailer_args => [
-           username => 'outreach@wormbase.org',
-           password => "$password",
-        ]
-    }
-  );
-  eval { $sender->send($email) };
-  die "Error sending email: $@" if $@;
+  print qq(send email to $emailaddress<br/>replyto $replyto<br/>subject $subject<br/>body $body<br/>);
+  # Jex::mailer sends through AWS SES and returns false if the send failed, so
+  # a paper is only flagged as emailed when the mail actually went out.
+  unless (&mailer('', $emailaddress, $subject, $body, '', 'text/plain', $replyto)) {
+    print qq(<span style="color:red">Error, the email was not sent, see the apache log for the reason.  This paper has not been marked as emailed.</span><br/>);
+    print qq(<a href="community_curation_tracker.cgi">back to start</a><br/>);
+    return;
+  }
   my @pgcommands;
   push @pgcommands, qq(DELETE FROM com_${datatype}_emailsent WHERE joinkey = '$papid';);
   push @pgcommands, qq(INSERT INTO com_${datatype}_emailsent VALUES ( '$papid', '$emailaddress'););

--- a/curation/website/priv/cgi-bin/omit_form.cgi
+++ b/curation/website/priv/cgi-bin/omit_form.cgi
@@ -14,9 +14,6 @@ use Jex;		# printHeader printFooter getHtmlVar getDate getSimpleDate mailer
 use LWP::UserAgent;	# getting sanger files for querying
 use LWP::Simple;	# get the PhenOnt.obo from a cgi
 use DBI;
-use Email::Send;
-use Email::Send::Gmail;
-use Email::Simple::Creator;
 use Tie::IxHash;
 use Dotenv -load => '/usr/lib/.env';
 

--- a/curation/website/pub/cgi-bin/forms/allele_sequence.cgi
+++ b/curation/website/pub/cgi-bin/forms/allele_sequence.cgi
@@ -20,6 +20,11 @@
 # Wen would like flatfile storage to parse later.  2025 12 18
 
 
+# Email now goes out through AWS SES with Jex::mailer, which reads
+# EMAIL_SMTP_USER and EMAIL_PASSWD from .env.  Google stopped accepting the
+# gmail app password some time between 2026 05 02 and 2026 05 12, and
+# regenerating it did not help.  2026 08 21
+
 use Jex;			# untaint, getHtmlVar, cshlNew
 use strict;
 use CGI;
@@ -1276,31 +1281,8 @@ sub getIp {
 # } # sub getUserByIp
 
 sub mailSendmail {
-  my ($user, $email, $subject, $body) = @_;
-  $email =~ s/\s+//g;
-  my @recipients = split/,/, $email;
-#   $cc =~ s/\s+//g;
-#   my @cc_recipients = split/,/, $cc;
-  my $smtp = Net::SMTP::SSL->new(
-    'smtp.gmail.com',                       # Gmail SMTP server address
-    Port => 465,                            # Gmail SMTP SSL port
-    Debug => 1,                             # Enable debugging if needed
-  ) or die "Could not connect to Gmail SMTP server";
-
-  $smtp->auth($ENV{MAILER_USERNAME}, $ENV{MAILER_PASSWORD});
-  $smtp->mail($ENV{MAILER_USERNAME});
-  # $smtp->to(@recipients);                     # might be an alternate way to send
-  $smtp->recipient(@recipients);
-#   $smtp->cc(@cc_recipients);                    # don't send cc
-  $smtp->data();
-  $smtp->datasend("From: <$ENV{MAILER_USERNAME}> \n");
-  $smtp->datasend("To: <$email> \n");
-#   $smtp->datasend("cc: <$cc> \n");
-  $smtp->datasend("Subject: $subject\n");
-  $smtp->datasend("Content-Type: text/html; charset=iso-8859-1 \n\n");
-  $smtp->datasend($body);
-  $smtp->dataend();
-  $smtp->quit;
+  my ($user, $email, $subject, $body, $cc) = @_;
+  return &mailer($user, $email, $subject, $body, $cc, 'text/html');	# Jex::mailer, sends through AWS SES
 } # sub mailSendmail
 
 sub OLDmailSendmail {

--- a/curation/website/pub/cgi-bin/forms/phenotype.cgi
+++ b/curation/website/pub/cgi-bin/forms/phenotype.cgi
@@ -111,6 +111,11 @@
 
 
 
+# Email now goes out through AWS SES with Jex::mailer, which reads
+# EMAIL_SMTP_USER and EMAIL_PASSWD from .env.  Google stopped accepting the
+# gmail app password some time between 2026 05 02 and 2026 05 12, and
+# regenerating it did not help.  2026 08 21
+
 use Jex;			# untaint, getHtmlVar, cshlNew
 use strict;
 use CGI;
@@ -2965,30 +2970,7 @@ sub getUserByIp {
 sub mailSendmail {
   my ($user, $email, $subject, $body, $cc) = @_;
   if ($ENV{DEVELOPMENT} eq 'true') { $subject = '[dev] ' . $subject; }
-  $email =~ s/\s+//g;
-  my @recipients = split/,/, $email;
-  $cc =~ s/\s+//g;
-  my @cc_recipients = split/,/, $cc;
-  my $smtp = Net::SMTP::SSL->new(
-    'smtp.gmail.com',                       # Gmail SMTP server address
-    Port => 465,                            # Gmail SMTP SSL port
-#     Debug => 1,                             # Enable debugging if needed
-  ) or die "Could not connect to Gmail SMTP server";
-
-  $smtp->auth($ENV{MAILER_USERNAME}, $ENV{MAILER_PASSWORD});
-  $smtp->mail($ENV{MAILER_USERNAME});
-  # $smtp->to(@recipients);			# might be an alternate way to send
-  $smtp->recipient(@recipients);
-  $smtp->cc(@cc_recipients);			# don't send cc
-  $smtp->data();
-  $smtp->datasend("From: <$ENV{MAILER_USERNAME}> \n");
-  $smtp->datasend("To: <$email> \n");
-  $smtp->datasend("cc: <$cc> \n");
-  $smtp->datasend("Subject: $subject\n");
-  $smtp->datasend("Content-Type: text/html; charset=iso-8859-1 \n\n");
-  $smtp->datasend($body);
-  $smtp->dataend();
-  $smtp->quit;
+  return &mailer($user, $email, $subject, $body, $cc, 'text/html');	# Jex::mailer, sends through AWS SES
 } # sub mailSendmail
 
 sub OLDmailSendmail {

--- a/curation/website/pub/cgi-bin/forms/strain_request.cgi
+++ b/curation/website/pub/cgi-bin/forms/strain_request.cgi
@@ -19,6 +19,11 @@
 # Add  heenam@caltech.edu  to email recepients.  2024 06 11
 
 
+# Email now goes out through AWS SES with Jex::mailer, which reads
+# EMAIL_SMTP_USER and EMAIL_PASSWD from .env.  Google stopped accepting the
+# gmail app password some time between 2026 05 02 and 2026 05 12, and
+# regenerating it did not help.  2026 08 21
+
 use Jex;			# untaint, getHtmlVar, cshlNew
 use strict;
 use CGI;
@@ -1316,31 +1321,8 @@ sub getIp {
 # } # sub getUserByIp
 
 sub mailSendmail {
-  my ($user, $email, $subject, $body) = @_;
-  $email =~ s/\s+//g;
-  my @recipients = split/,/, $email;
-#   $cc =~ s/\s+//g;
-#   my @cc_recipients = split/,/, $cc;
-  my $smtp = Net::SMTP::SSL->new(
-    'smtp.gmail.com',                       # Gmail SMTP server address
-    Port => 465,                            # Gmail SMTP SSL port
-#     Debug => 1,                             # Enable debugging if needed
-  ) or die "Could not connect to Gmail SMTP server";
-
-  $smtp->auth($ENV{MAILER_USERNAME}, $ENV{MAILER_PASSWORD});
-  $smtp->mail($ENV{MAILER_USERNAME});
-  # $smtp->to(@recipients);                     # might be an alternate way to send
-  $smtp->recipient(@recipients);
-#   $smtp->cc(@cc_recipients);                    # don't send cc
-  $smtp->data();
-  $smtp->datasend("From: <$ENV{MAILER_USERNAME}> \n");
-  $smtp->datasend("To: <$email> \n");
-#   $smtp->datasend("cc: <$cc> \n");
-  $smtp->datasend("Subject: $subject\n");
-  $smtp->datasend("Content-Type: text/html; charset=iso-8859-1 \n\n");
-  $smtp->datasend($body);
-  $smtp->dataend();
-  $smtp->quit;
+  my ($user, $email, $subject, $body, $cc) = @_;
+  return &mailer($user, $email, $subject, $body, $cc, 'text/html');	# Jex::mailer, sends through AWS SES
 } # sub mailSendmail
 
 sub OLDmailSendmail {

--- a/curation/website/pub/cgi-bin/forms/webinar.cgi
+++ b/curation/website/pub/cgi-bin/forms/webinar.cgi
@@ -20,6 +20,13 @@
 
 
 
+# Email now goes out through AWS SES with Jex::mailer, which reads
+# EMAIL_SMTP_USER and EMAIL_PASSWD from .env.  The outreach@wormbase.org
+# password file is no longer read: SES cannot sign for wormbase.org, so the
+# visible sender is EMAIL_FROM and the outreach account stays as the Reply-To.
+# Google stopped accepting the gmail app password some time between 2026 05 02
+# and 2026 05 12, and regenerating it did not help.  2026 08 21
+
 use Jex;			# untaint, getHtmlVar, cshlNew
 use strict;
 use CGI;
@@ -29,9 +36,6 @@ use Tie::IxHash;
 use LWP::Simple;
 use File::Basename;		# fileparse
 # use Mail::Sendmail;
-use Email::Send;
-use Email::Send::Gmail;
-use Email::Simple::Creator;
 use Net::Domain qw(hostname hostfqdn hostdomain);
 use Dotenv -load => '/usr/lib/.env';
 
@@ -969,53 +973,10 @@ sub checkIpBlock {
 
 sub mailSendmail {
   my ($user, $email, $subject, $body) = @_;
-
-# EMAIL locally
-#   $user = 'wormbase-webinar@mangolassi.caltech.edu';
-#   my %mail;
-#   $mail{from}           = $user;
-#   $mail{to}             = $email;
-#   $mail{subject}        = $subject;
-#   $mail{body}           = $body;
-#   $mail{'content-type'} = 'text/html; charset="iso-8859-1"';
-# # UNCOMMENT TO SEND EMAIL
-#   sendmail(%mail) || print qq(<span style="color:red">Error, confirmation email failed</span> : $Mail::Sendmail::error<br/>\n);
-
-# GMAIL way 
-  my $emailaddress = $email;
-#   ($var, my $emailaddress)   = &getHtmlVar($query, 'email');
-#   ($var, my $subject)        = &getHtmlVar($query, 'subject');
-#   ($var, my $body)           = &getHtmlVar($query, 'body');
-  my $sender = 'outreach@wormbase.org';
-#   my $replyto = 'curation@wormbase.org';
-#   print qq(send email to $emailaddress<br/>from $sender<br/>replyto $replyto<br/>subject $subject<br/>body $body<br/>);
-#   print qq(send email to $emailaddress<br/>from $sender<br/>subject $subject<br/>body $body<br/>);
-  my $email = Email::Simple->create(
-    header => [
-        From       => 'outreach@wormbase.org',
-        To         => "$emailaddress",
-        Subject    => "$subject",
-        'Content-Type' => 'text/html',
-    ],
-    body => "$body",
-  );
-
-  my $passfile = $ENV{CALTECH_CURATION_FILES_INTERNAL_PATH} . '/insecure/outreachwormbase';
-  # my $passfile = '/home/postgres/insecure/outreachwormbase';
-  open (IN, "<$passfile") or die "Cannot open $passfile : $!";
-  my $password = <IN>; chomp $password;
-  close (IN) or die "Cannot close $passfile : $!";
-  my $sender = Email::Send->new(
-    {   mailer      => 'Gmail',
-        mailer_args => [
-           username => 'outreach@wormbase.org',
-           password => "$password",
-        ]
-    }
-  );
-  eval { $sender->send($email) };
-  die "Error sending email: $@" if $@;
-
+  # Jex::mailer sends through AWS SES.  The visible sender is EMAIL_FROM rather
+  # than outreach@wormbase.org, which SES cannot sign for, but replies still go
+  # to the outreach account through the Reply-To that mailer sets.
+  return &mailer($user, $email, $subject, $body, '', 'text/html');
 } # sub mailSendmail
 
 sub autocompleteXHR {                                           # when typing in an autocomplete field xhr call to this CGI for values


### PR DESCRIPTION
Hi Juancarlos - this is the fix for the emails not going out since early May.

## Why

Google stopped accepting the gmail app password for our accounts some time
between May 2 and May 12. I revoked the old one and generated new ones to rule
out an expired credential, and the new ones fail exactly the same way, so this
is not a password we can rotate. I hit the same thing at the same time on
ACKnowledge and the barista TPC counters, both of which authenticated to gmail
with an account plus an app password. I moved those two to AWS SES and they have
been fine since. This PR does the same for the curation server.

## What changed

There were three separate mail stacks in the repo, all pointed at gmail:

1. `Jex::mailer`, which 24 scripts and forms call
2. six copy-pasted versions of the same gmail block (phenotype, strain_request,
   allele_sequence, and three topic-entity-species scripts)
3. three senders using the deprecated `Email::Send::Gmail` with the
   `outreach@wormbase.org` password sitting in plaintext, world readable, in
   `$CALTECH_CURATION_FILES/insecure/outreachwormbase` (webinar, community
   curation tracker, community curation mass mailer)

All of them now go through `Jex::mailer`, which talks to AWS SES over SMTP. The
passfile is no longer read. `omit_form.cgi` only had leftover `Email::Send`
imports and never sent anything, so those are gone too. Nothing outside
`old_scripts_and_forms/` references `smtp.gmail.com`, `MAILER_USERNAME` or
`Email::Send::Gmail` any more.

`mailer()` keeps its old four-argument signature, so none of the 24 existing
call sites changed. It gained three optional arguments - `$cc`,
`$content_type`, `$reply_to` - which is what let the ten duplicates collapse
onto it.

Worth knowing while reviewing: all three stacks were sending as the *same*
address. `MAILER_USERNAME` in the prod env file is `outreach@wormbase.org`, the
same account the passfile senders authenticated as - the three stacks differed
only in how they authenticated, not in who the mail came from. So there was one
sender identity to replace, not two.

The first argument to `mailer()` is a per-form label - `phenotype_form@<host>`,
`two_point_data_form`, `check_apache_simplemine` and so on - which was the From
back when this went through `Mail::Mailer` and sendmail (`old_tazendra_mailer`
still shows `From => $user`). It has been ignored ever since the move to gmail
smtp, and several of the values are not valid addresses anyway. I kept the
argument so the call sites did not have to change, but if we ever want per-form
senders back, SES would allow it: the verified parent domain covers anything at
`@caltech-curation.textpressolab.com`, so `phenotype-form@...` etc. would work.
Happy to do that in a follow-up if you think it is useful for filtering.

## Configuring it

Two variables are required. They are the SES SMTP credentials from the
textpresso AWS account, and deliberately the same two names the ACKnowledge and
barista backends already use:

```
EMAIL_SMTP_USER=<SES smtp username>
EMAIL_PASSWD=<SES smtp password>
```

Four more are optional. When empty, `Jex.pm` uses these defaults:

| variable | default |
| --- | --- |
| `EMAIL_HOST` | `email-smtp.us-east-1.amazonaws.com` |
| `EMAIL_PORT` | `465` |
| `EMAIL_FROM` | `WormBase Curation <no-reply@caltech-curation.textpressolab.com>` |
| `EMAIL_REPLY_TO` | empty, see below |

`EMAIL_SMTP_USER` is an opaque SES credential, **not** an address - that is the
one real difference from gmail, where the username doubled as the sender. So the
visible sender comes from `EMAIL_FROM`, which has to be an SES-verified
identity. `textpressolab.com` is verified as a parent domain in that account, so
any subdomain of it sends without extra DNS work.

Because that From is a `no-reply@` address, `mailer` always sets a `Reply-To`,
and by default it is **every address the message went to** - the submitter plus
the curators in To and Cc - so a submitter hitting reply reaches all the
curators on the thread, which is how these forms have always been read. Leaving
the header off is not an option: the old From was `outreach@wormbase.org`, a
mailbox somebody watches, so a plain reply used to land somewhere, whereas
`EMAIL_FROM` has to be an address SES can sign for. Setting `EMAIL_REPLY_TO`
pins every reply to one fixed mailbox instead, and an individual call can pass
its own - the community curation tracker and mass mailer pass
`curation@wormbase.org`, as they did before.

If we would rather send as `outreach@wormbase.org` itself, that needs three SES
DKIM CNAME records added to `wormbase.org` DNS by whoever manages it. Worth
knowing either way: `wormbase.org` currently publishes no SPF record at all, so
our outgoing mail is already unauthenticated - adding DKIM would make this
better than it was before, not just equal.

### Two places to set them

**The `.env` file** is what the server needs, because Apache's CGI children and
the cron jobs only ever read `/usr/lib/.env` through `Dotenv`. On prod that file
is the host file mounted there:

```
/usr/share/caltech-curation-services/env_files/.env.caltech-curation-prod
```

No restart needed for a change to it - each CGI or cron invocation re-reads the
file. The `.env` template in the repo now lists the six variable names with
empty values so the shape is documented.

**Real environment variables also work, and they win.** I checked this against
the running container rather than assuming it: `Dotenv` 0.002 does not overwrite
anything already in the environment.

```
docker exec -e HOST_NAME=OVERRIDE_WINS <curation> perl -e 'use Dotenv -load => "/usr/lib/.env"; print $ENV{HOST_NAME}'
-> OVERRIDE_WINS
```

So anything injected into the environment - a Jenkins credential binding, a
`docker compose run -e`, an export in a wrapper script - overrides the file for
that process. Valerio is handling the Jenkins side.

One consequence worth flagging, because it is the kind of thing someone
reasonably "tidies up" later: **do not add the `EMAIL_*` variables to the
`curation` service's `environment:` block in `docker-compose.yml`.** Since
`Dotenv` yields to whatever is already set, an empty value there would shadow
the real one in the env file and silently break sending. That is why they are
not in the compose file.

## Deploying

`Jex.pm` is copied into the image by `curation/Dockerfile:39`, it is not bind
mounted, so this one needs a rebuild rather than a restart:

```bash
docker compose up -d --build curation
```

Restarting only would leave the old gmail mailer running while the source looks
updated, which is a confusing failure mode, so `test_mailer.pl` compares the
`Jex.pm` it loaded against the one in the mounted source tree and warns when
they differ.

## Testing it

`curation/scripts/test_mailer.pl` sends one message through exactly the code
path the forms use - `use Jex` -> `Dotenv` on `/usr/lib/.env` -> `&mailer`:

```bash
make test-mailer TO=you@example.org
```

It prints the resolved configuration (never the credentials themselves, just
"set (N characters)"), sends, and exits 0 or 1 with the likely causes listed on
failure. It uses `run --rm --no-deps`, so it works whether or not the service is
up. To try credentials without editing the env file first:

```bash
export EMAIL_SMTP_USER='...'
read -rs EMAIL_PASSWD; export EMAIL_PASSWD     # keeps it out of shell history
make test-mailer TO=you@example.org
```

On a laptop add `COMPOSE_ARGS='--env-file .env.local'`, since the repo `.env`
leaves `SRC_DIR_PATH` and `ENV_FILE_PATH` empty. Also note the prod host only
has the compose v2 plugin, so the Makefile uses `docker compose`; override with
`COMPOSE=docker-compose` on older machines.

## Behaviour changes worth a look

- **Send failures are logged and returned, not fatal.** Form submissions are
  already written to postgres by the time the confirmation goes out, so dying
  showed the submitter an error for data that did save. Every outcome now logs
  a line prefixed `mailer:` with the SMTP code and message, so an outage is
  visible instead of silent - the existing grok_exporter setup could scrape
  that later if we want a metric.
- **A rejected recipient no longer kills the whole message.** `recipient()` is
  called with `SkipBad`, so if a submitter typos their own address, or SES
  refuses an unverified recipient while the account is in the sandbox, the
  curators' copy still goes out. That matches what the gmail code did, which
  ignored the return value.
- **`com_massemail` and `com_*_emailsent` are only written after a successful
  send.** These drive the "already contacted" logic, and the old mass mailer
  inserted before sending, so a credentials failure would have marked every
  author as contacted while sending nothing, and they would never be asked
  again.
- **HTML mail is `charset=UTF-8` instead of `iso-8859-1`.** The old declaration
  was wrong given that form input is utf-8; this matches 0d00695.
- **The visible sender changes for everything, not just the three outreach
  senders.** `MAILER_USERNAME` on prod is itself `outreach@wormbase.org`, so
  every form, cron report and mailing was already going out as that address,
  whichever of the three stacks it used. From now on the From is `EMAIL_FROM`
  and `outreach@wormbase.org` is the Reply-To. Anyone filtering on the old
  sender needs to update their rule, and that means anyone filtering on any
  curation mail at all.

### Recipients are untouched

Worth stating explicitly since it is the thing most likely to go wrong in a
change like this: no To or Cc line was modified anywhere. Chris (`cgrove@`),
Daniela (`draciti@`), Cecilia (`cecnak@`), Wen, Gary, the `genenames@` list and
the strain request recipients all get exactly what they got before, and the
submitter still gets their copy from the address they typed into the form. The
only address lines in the whole diff are sender, auth and Reply-To lines.

One recipient-side improvement: a rejected address no longer takes the whole
message down, so a submitter typo, or SES refusing an unverified recipient while
the account is in the sandbox, does not drop the curators' copy.

## What is not in this PR

- **The strain request form still stores nothing.** Its only INSERT is
  `two_user_ip` (IP tracking); the request itself exists only in the email it
  sends, to a hardcoded list. Requests submitted during this outage are gone.
  That needs a table, so it is a separate change - but it is the one I would do
  next.
- A proper delivery log. Right now the record is the `mailer:` log lines.
- Verifying `wormbase.org` in SES, which needs DNS access.

## Verification

`perl -c` passes on all twelve changed Perl files. Beyond that I exercised
`Jex::mailer` end to end against a TLS SMTP server I stood up locally, since I
do not have the SES credentials:

- success: envelope `MAIL FROM` is the bare address with the display name
  stripped, `RCPT TO` includes the Cc recipients, headers carry
  From/To/Cc/Reply-To/RFC-2047 subject/content-type, and utf-8 body bytes are
  correct on the wire
- one of three recipients rejected: still delivered to the other two, names the
  rejected one, returns true
- every recipient rejected, auth rejected (535), sender not verified (553),
  DATA refused (454 throttling), credentials missing, host unreachable, no
  recipients: all return false with an actionable log line

What I could not test is a real SES handshake - that is what `test_mailer.pl`
is for once the credentials are in. TCP 465 to SES is reachable from the
container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


